### PR TITLE
Fix Typo in Template 

### DIFF
--- a/templates/Engine method templates/ComputeTemplate/ComputeTemplate.cs
+++ b/templates/Engine method templates/ComputeTemplate/ComputeTemplate.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 
-namespace $rootnamespace$ //`Compute` is a partial class. Remove any reference to `Compute` the from namespace.
+namespace $rootnamespace$ //`Compute` is a partial class. Remove any reference to `Compute` from the namespace.
 {
     public static partial class Compute
     {

--- a/templates/Engine method templates/ConvertTemplate/ConvertTemplate.cs
+++ b/templates/Engine method templates/ConvertTemplate/ConvertTemplate.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 
-namespace $rootnamespace$ //`Convert` is a partial class. Remove any reference to `Convert` the from namespace.
+namespace $rootnamespace$ //`Convert` is a partial class. Remove any reference to `Convert` from the namespace.
 {
     public static partial class Convert
     {

--- a/templates/Engine method templates/CreateTemplate/CreateTemplate.cs
+++ b/templates/Engine method templates/CreateTemplate/CreateTemplate.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 
-namespace $rootnamespace$ //`Create` is a partial class. Remove any reference to `Create` the from namespace.
+namespace $rootnamespace$ //`Create` is a partial class. Remove any reference to `Create` from the namespace.
 {
     public static partial class Create
     {

--- a/templates/Engine method templates/ModifyTemplate/ModifyTemplate.cs
+++ b/templates/Engine method templates/ModifyTemplate/ModifyTemplate.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 
-namespace $rootnamespace$ //`Modify` is a partial class. Remove any reference to `Modify` the from namespace.
+namespace $rootnamespace$ //`Modify` is a partial class. Remove any reference to `Modify` from the namespace.
 {
     public static partial class Modify
     {

--- a/templates/Engine method templates/QueryTemplate/QueryTemplate.cs
+++ b/templates/Engine method templates/QueryTemplate/QueryTemplate.cs
@@ -27,7 +27,7 @@ using System.ComponentModel;
 using BH.oM.Base.Attributes;
 using BH.oM.Base;
 
-namespace $rootnamespace$ //`Query` is a partial class. Remove any reference to `Query` the from namespace.
+namespace $rootnamespace$ //`Query` is a partial class. Remove any reference to `Query` from the namespace.
 {
     public static partial class Query
     {


### PR DESCRIPTION
Closes #50 

Simple typo fix.


### Changelog

- `Query` - Partial class template modified for typo in comment on namespace naming.
- `Compute` - Partial class template modified for typo in comment on namespace naming.
- `Convert` - Partial class template modified for typo in comment on namespace naming.
- `Modify` - Partial class template modified for typo in comment on namespace naming.
- `Create` - Partial class template modified for typo in comment on namespace naming.
