### PR TITLE
 Corrected Spacing

### DIFF
--- a/docs/Contributing/Development FAQ/Coding-Style.md
+++ b/docs/Contributing/Development FAQ/Coding-Style.md
@@ -15,13 +15,16 @@ BHoM code also adheres to customised rules and style guidelines. These are in pl
 - to organise functionality and classes in a tidy, easy-to-find manner.
 
 
-### Access Modifiers
+### Access modifiers
+
 Access modifiers specify the accessibility level of type and type members. They denote whether a type or member can be used by other code in the same assembly, and in other assemblies.
 - In line with BHoM's focus on clarity and transparency, we generally use the `public` access modifier, which allows a type or member to be accessed by any other code in the same assembly or other assembly that reference it.
 - When absolutely necessary, we use the `private` access modifier to limit the access of a type or member to only code in the same class.
 - Although C# provides many [access modifiers](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers), we limit our use to the two mentioned above.
 
+
 ### Filenames, objects and methods
+
 - A `.cs` file can contain only 1 (one) `class`, and there is no concept as a `Helper` or `Utils` class.
 - For **oM objects** the name of the `.cs` file is the Name (excluding the namespace) of the Object (class), e.g. the `Line` class is in the `Line.cs` file.
 - For **engine methods**, a file can only contain methods whose name start or end with the name of their file file, e.g. `Flip(Line line)` and `Flip(Arc arc)` are in the same file `Flip.cs`, and `FilterPanels` and `FilterOpenings` can both reside inside a `Filter.cs` file.

--- a/docs/Contributing/Development FAQ/Coding-Style.md
+++ b/docs/Contributing/Development FAQ/Coding-Style.md
@@ -18,6 +18,7 @@ BHoM code also adheres to customised rules and style guidelines. These are in pl
 ### Access modifiers
 
 Access modifiers specify the accessibility level of type and type members. They denote whether a type or member can be used by other code in the same assembly, and in other assemblies.
+
 - In line with BHoM's focus on clarity and transparency, we generally use the `public` access modifier, which allows a type or member to be accessed by any other code in the same assembly or other assembly that reference it.
 - When absolutely necessary, we use the `private` access modifier to limit the access of a type or member to only code in the same class.
 - Although C# provides many [access modifiers](https://learn.microsoft.com/en-us/dotnet/csharp/programming-guide/classes-and-structs/access-modifiers), we limit our use to the two mentioned above.


### PR DESCRIPTION
-bullet points for Access Modifier not showing up on [wiki webpage](https://bhom.xyz/documentation/Contributing/Development%20FAQ/Coding-Style/#access-modifiers )
-in preview it was showing up, the only difference I can detect between Access Modifier section and others is spacing, so I adjusted accordingly